### PR TITLE
fix: Handle z-index less weirdly

### DIFF
--- a/api/src/main/java/com/noxcrew/sheeplib/mixin/PlayerTabOverlayMixin.java
+++ b/api/src/main/java/com/noxcrew/sheeplib/mixin/PlayerTabOverlayMixin.java
@@ -2,27 +2,25 @@ package com.noxcrew.sheeplib.mixin;
 
 import com.noxcrew.sheeplib.DialogContainer;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.components.SubtitleOverlay;
+import net.minecraft.client.gui.components.PlayerTabOverlay;
+import net.minecraft.world.scores.Objective;
+import net.minecraft.world.scores.Scoreboard;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
- * Increases the subtitle overlay's Z-axis to render on top of SheepLib dialogs.
+ * Increases the player tab overlay's Z-axis to render on top of SheepLib dialogs.
  */
-@Mixin(SubtitleOverlay.class)
-public class SubtitleOverlayMixin {
-    @SuppressWarnings({"MixinAnnotationTarget", "UnresolvedMixinReference"})
+@Mixin(PlayerTabOverlay.class)
+public class PlayerTabOverlayMixin {
+
     @Inject(
             method = "render",
-            at = @At(
-                    value = "NEW",
-                    target = "net/minecraft/world/phys/Vec3",
-                    ordinal = 0
-            )
+            at = @At("HEAD")
     )
-    public void pushPose(GuiGraphics guiGraphics, CallbackInfo ci) {
+    public void pushPose(GuiGraphics guiGraphics, int i, Scoreboard scoreboard, Objective objective, CallbackInfo ci) {
         guiGraphics.pose().pushPose();
         guiGraphics.pose().translate(0.0, 0.0, DialogContainer.zIndexUse$sheeplib());
     }
@@ -31,7 +29,7 @@ public class SubtitleOverlayMixin {
             method = "render",
             at = @At("TAIL")
     )
-    public void popPose(GuiGraphics guiGraphics, CallbackInfo ci) {
+    public void popPose(GuiGraphics guiGraphics, int i, Scoreboard scoreboard, Objective objective, CallbackInfo ci) {
         guiGraphics.pose().popPose();
     }
 }

--- a/api/src/main/java/com/noxcrew/sheeplib/mixin/SubtitleOverlayMixin.java
+++ b/api/src/main/java/com/noxcrew/sheeplib/mixin/SubtitleOverlayMixin.java
@@ -1,0 +1,36 @@
+package com.noxcrew.sheeplib.mixin;
+
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.SubtitleOverlay;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Increases the subtitle overlay's Z-axis to render on top of SheepLib dialogs.
+ */
+@Mixin(SubtitleOverlay.class)
+public class SubtitleOverlayMixin {
+    @SuppressWarnings({"MixinAnnotationTarget", "UnresolvedMixinReference"})
+    @Inject(
+            method = "render",
+            at = @At(
+                    value = "NEW",
+                    target = "net/minecraft/world/phys/Vec3",
+                    ordinal = 0
+            )
+    )
+    public void pushPose(GuiGraphics guiGraphics, CallbackInfo ci) {
+        guiGraphics.pose().pushPose();
+        guiGraphics.pose().translate(0.0, 0.0, 200.0);
+    }
+
+    @Inject(
+            method = "render",
+            at = @At("TAIL")
+    )
+    public void popPose(GuiGraphics guiGraphics, CallbackInfo ci) {
+        guiGraphics.pose().popPose();
+    }
+}

--- a/api/src/main/kotlin/com/noxcrew/sheeplib/DialogContainer.kt
+++ b/api/src/main/kotlin/com/noxcrew/sheeplib/DialogContainer.kt
@@ -34,7 +34,13 @@ public object DialogContainer : Renderable, ContainerEventHandler, NarratableEnt
     private var isDragging: Boolean = false
 
     /** The step to offset each dialog by in the Z-axis. */
-    private const val Z_OFFSET: Float = 5f
+    private const val Z_STEP_PER_DIALOG = 5f
+
+    /**
+     * The amount to offset the initial Z co-ordinate by, for all dialogs.
+     * This is needed to sit on top of the vanilla chat window.
+     */
+    private const val Z_INITIAL_OFFSET = 100f
 
     /** Renders widgets. */
     override fun render(guiGraphics: GuiGraphics, i: Int, j: Int, f: Float) {
@@ -44,9 +50,9 @@ public object DialogContainer : Renderable, ContainerEventHandler, NarratableEnt
         val childY = if (cursorIsActive) j else -1
 
         guiGraphics.pose().pushPose()
-        guiGraphics.pose().translate(0f, 0f, 100f) // 2 x 50 to get over the top of the chat.
+        guiGraphics.pose().translate(0f, 0f, Z_INITIAL_OFFSET)
         children.value.forEach {
-            guiGraphics.pose().translate(0f, 0f, Z_OFFSET)
+            guiGraphics.pose().translate(0f, 0f, Z_STEP_PER_DIALOG)
             (it as Renderable).render(guiGraphics, childX, childY, f)
         }
         guiGraphics.pose().popPose()
@@ -144,4 +150,11 @@ public object DialogContainer : Renderable, ContainerEventHandler, NarratableEnt
 
     /** Unused. */
     override fun narrationPriority(): NarratableEntry.NarrationPriority = NarratableEntry.NarrationPriority.NONE
+
+    /**
+     * The total amount of space in the Z axis that the dialogs have used,
+     * assuming each dialog spans across no more than [Z_STEP_PER_DIALOG].
+     */
+    @JvmStatic
+    internal fun zIndexUse() = Z_INITIAL_OFFSET + ((children.value.size + 1) * Z_STEP_PER_DIALOG)
 }

--- a/api/src/main/kotlin/com/noxcrew/sheeplib/DialogContainer.kt
+++ b/api/src/main/kotlin/com/noxcrew/sheeplib/DialogContainer.kt
@@ -44,7 +44,7 @@ public object DialogContainer : Renderable, ContainerEventHandler, NarratableEnt
         val childY = if (cursorIsActive) j else -1
 
         guiGraphics.pose().pushPose()
-        guiGraphics.pose().translate(0f, 0f, -children.value.size * Z_OFFSET)
+        guiGraphics.pose().translate(0f, 0f, 100f) // 2 x 50 to get over the top of the chat.
         children.value.forEach {
             guiGraphics.pose().translate(0f, 0f, Z_OFFSET)
             (it as Renderable).render(guiGraphics, childX, childY, f)

--- a/api/src/main/resources/sheeplib.mixins.json
+++ b/api/src/main/resources/sheeplib.mixins.json
@@ -1,8 +1,9 @@
 {
-  "package": "com.noxcrew.sheeplib.mixin",
-  "client": [
-    "ChatScreenMixin",
-    "GuiMixin",
-    "StringWidgetMixin"
+    "package": "com.noxcrew.sheeplib.mixin",
+    "client": [
+        "ChatScreenMixin",
+        "GuiMixin",
+        "StringWidgetMixin",
+        "SubtitleOverlayMixin"
   ]
 }

--- a/api/src/main/resources/sheeplib.mixins.json
+++ b/api/src/main/resources/sheeplib.mixins.json
@@ -3,7 +3,8 @@
     "client": [
         "ChatScreenMixin",
         "GuiMixin",
+        "PlayerTabOverlayMixin",
         "StringWidgetMixin",
         "SubtitleOverlayMixin"
-  ]
+    ]
 }

--- a/test-mod/src/main/kotlin/com/noxcrew/sheeplib/testmod/AdjustableZIndexDialog.kt
+++ b/test-mod/src/main/kotlin/com/noxcrew/sheeplib/testmod/AdjustableZIndexDialog.kt
@@ -1,0 +1,31 @@
+package com.noxcrew.sheeplib.testmod
+
+import com.noxcrew.sheeplib.dialog.Dialog
+import com.noxcrew.sheeplib.layout.grid
+import com.noxcrew.sheeplib.theme.DefaultTheme
+import com.noxcrew.sheeplib.theme.Themed
+import com.noxcrew.sheeplib.widget.SliderWidget
+import net.minecraft.client.gui.GuiGraphics
+import net.minecraft.client.gui.layouts.Layout
+import org.slf4j.LoggerFactory
+
+/** A dialog with an adjustable Z index. */
+public class AdjustableZIndexDialog(x: Int, y: Int) : Dialog(x, y), Themed by DefaultTheme {
+
+    private var index: Int = 0
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    override fun render(graphics: GuiGraphics, i: Int, j: Int, f: Float) {
+        graphics.pose().pushPose()
+        graphics.pose().translate(0f, 0f, index.toFloat())
+        super.render(graphics, i, j, f)
+        graphics.pose().popPose()
+    }
+
+    override fun layout(): Layout = grid {
+        SliderWidget(500, 0, 100, this@AdjustableZIndexDialog) {
+            index = it
+            logger.info(it.toString())
+        }.atBottom(0)
+    }
+}

--- a/test-mod/src/main/kotlin/com/noxcrew/sheeplib/testmod/SheepLibTestMod.kt
+++ b/test-mod/src/main/kotlin/com/noxcrew/sheeplib/testmod/SheepLibTestMod.kt
@@ -33,7 +33,8 @@ public object SheepLibTestMod : ClientModInitializer {
         "text" to ::textInputDialog,
         "progress" to ::ProgressDialog,
         "buttons" to ::ButtonCollectionsDialog,
-        "exception" to ::ExceptionDialog
+        "exception" to ::ExceptionDialog,
+        "z-index" to ::AdjustableZIndexDialog
     )
 
 


### PR DESCRIPTION
FIxes #2.

Before, dialogs were rendered at a fixed Z-axis, with older dialogs moving futher back the more dialogs were on screen. This led to dialogs inconsistently overlapping with vanilla UI elements.

This PR changes that behaviour to start above chat, increasing the Z-index per-dialog to correctly overlap them depending on focus. It also increases the subtitle overlay's Z-index to sit on top of dialogs. 